### PR TITLE
PROCESS: Containers images dependencies fixed.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   couchdb:
-    image: couchdb
+    image: couchdb:2
     ports:
       - 5984:5984
     volumes:
@@ -25,7 +25,7 @@ services:
     working_dir: /app
 
   ldap_proxy:
-    image: benel/aaaforrest
+    image: benel/aaaforrest:1.0.0
     ports:
       - 80:80 #
     volumes:


### PR DESCRIPTION
Au moment de mettre à jour ma copie de Cassandre, je me suis rendu compte que les dernières versions des images de conteneurs référencées n'était plus compatibles.
En attendant une mise à jour plus profonde, le fait de préciser la version permet de faire fonctionner l'ensemble.