### PR TITLE
Logging format should be usable for production.

### DIFF
--- a/conf/aaaforrest.yml
+++ b/conf/aaaforrest.yml
@@ -2,7 +2,7 @@ port: 80
 service: proxy
 path: ''
 secret: TO_BE_CHANGED
-logFormat: dev
+logFormat: :date[iso] :remote-addr :remote-user :method :url :status :response-time[0]ms :total-time[0]ms ":user-agent"
 session:
   proxy: true
   cookie:


### PR DESCRIPTION
Recent requests for usage statistics as well as the frequent need for stress tuning make me realize that Cassandre (and other software from the suite) requires extensive logs by default.

Here is how the new format is loaded in a a spreadsheet software (with space as the column separator, double quote as a group formatter, and defining the correct type for time columns):
<img width="846" alt="Capture d’écran 2022-09-25 à 15 47 10" src="https://user-images.githubusercontent.com/597307/192149458-d229012c-adc8-41d7-8168-d97563001087.png">
Note: Data are from the AAAforREST test suite (in normal settings, the last column is the browser). 

Please note that **this setting requires AAAforREST to be updated** with `docker-compose pull` (and `down` and `up`).