### PR TITLE
FIX: Cassandre proxy container should run also on old dockers.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     restart: on-failure
 
   proxy:
-    image: node:lts
+    image: node:lts-bullseye-slim
     command: sh -c "npm install && npm start"
 #    ports:
 #      - 80:80


### PR DESCRIPTION
At UTT, after pulling the updated container images of Cassandre, the proxy couldn't be started again.

This fix allowed me to start Cassandre proxy again. 