### PR TITLE
DOC: Starting Cassandre requires setting CouchDB admin credentials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Installation requirements
 Installation procedure
 ----------------------
 
-    docker-compose up -d
+    export COUCHDB_USER="TO_BE_CHANGED"
+    export COUCHDB_PASSWORD="TO_BE_CHANGED"
+    docker compose up --detach
 
 Two services are now available:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
     volumes:
       - ./data:/opt/couchdb/data
       - ./conf/couchdb.ini:/opt/couchdb/etc/local.d/docker.ini
+    environment:
+      - COUCHDB_USER
+      - COUCHDB_PASSWORD
     logging:
       options:
         max-size: "1M"


### PR DESCRIPTION
Commit intended to people testing Cassandre for the first time.